### PR TITLE
nrfx_spi: Make possible to skip GPIO configuration in nrfx_spi_init()

### DIFF
--- a/drivers/include/nrfx_spi.h
+++ b/drivers/include/nrfx_spi.h
@@ -107,10 +107,10 @@ typedef struct
     nrf_spi_mode_t      mode;       ///< SPI mode.
     nrf_spi_bit_order_t bit_order;  ///< SPI bit order.
     nrf_gpio_pin_pull_t miso_pull;  ///< MISO pull up configuration.
-    bool               skip_gpio_cfg; ///< Skip the GPIO configuration
-                                      /**< When this flag is set, the user is responsible for
-                                       *   providing the proper configuration of the output pins,
-                                       *   as the driver does not touch it at all. */
+    bool                skip_gpio_cfg; ///< Skip the GPIO configuration
+                                       /**< When this flag is set, the user is responsible for
+                                        *   providing the proper configuration of the output pins,
+                                        *   as the driver does not touch it at all. */
 } nrfx_spi_config_t;
 
 /**

--- a/drivers/include/nrfx_spi.h
+++ b/drivers/include/nrfx_spi.h
@@ -107,6 +107,7 @@ typedef struct
     nrf_spi_mode_t      mode;       ///< SPI mode.
     nrf_spi_bit_order_t bit_order;  ///< SPI bit order.
     nrf_gpio_pin_pull_t miso_pull;  ///< MISO pull up configuration.
+    bool                skip_gpio_cfg; /**< Do not change GPIO configuration */
 } nrfx_spi_config_t;
 
 /**
@@ -133,6 +134,7 @@ typedef struct
     .frequency    = NRF_SPI_FREQ_4M,                                        \
     .mode         = NRF_SPI_MODE_0,                                         \
     .bit_order    = NRF_SPI_BIT_ORDER_MSB_FIRST,                            \
+    .skip_gpio_cfg = false                                                \
 }
 
 /** @brief Single transfer descriptor structure. */

--- a/drivers/include/nrfx_spi.h
+++ b/drivers/include/nrfx_spi.h
@@ -107,7 +107,10 @@ typedef struct
     nrf_spi_mode_t      mode;       ///< SPI mode.
     nrf_spi_bit_order_t bit_order;  ///< SPI bit order.
     nrf_gpio_pin_pull_t miso_pull;  ///< MISO pull up configuration.
-    bool                skip_gpio_cfg; /**< Do not change GPIO configuration */
+    bool               skip_gpio_cfg; ///< Skip the GPIO configuration
+                                      /**< When this flag is set, the user is responsible for
+                                       *   providing the proper configuration of the output pins,
+                                       *   as the driver does not touch it at all. */
 } nrfx_spi_config_t;
 
 /**
@@ -134,7 +137,7 @@ typedef struct
     .frequency    = NRF_SPI_FREQ_4M,                                        \
     .mode         = NRF_SPI_MODE_0,                                         \
     .bit_order    = NRF_SPI_BIT_ORDER_MSB_FIRST,                            \
-    .skip_gpio_cfg = false                                                \
+    .skip_gpio_cfg = false                                                  \
 }
 
 /** @brief Single transfer descriptor structure. */


### PR DESCRIPTION
Add the skip_gpio_cfg field to the nrfx_spi_config_t structure in nrfx_spi.h and initialize it to false.

Skip the gpio setting by adding an if branc In nrfx_spi.c.