### PR TITLE
nrfx_spis: Make possible to skip GPIO configuration in nrfx_spis_init()

### DIFF
--- a/drivers/include/nrfx_spis.h
+++ b/drivers/include/nrfx_spis.h
@@ -154,8 +154,8 @@ typedef struct
     uint8_t              irq_priority;  //!< Interrupt priority.
     bool                 skip_gpio_cfg; ///< Skip the GPIO configuration
                                         /**< When this flag is set, the user is responsible for
-                                        *   providing the proper configuration of the output pins,
-                                        *   as the driver does not touch it at all. */
+                                         *   providing the proper configuration of the output pins,
+                                         *   as the driver does not touch it at all. */
 } nrfx_spis_config_t;
 
 

--- a/drivers/include/nrfx_spis.h
+++ b/drivers/include/nrfx_spis.h
@@ -131,6 +131,7 @@ typedef struct
     .def          = 0xFF,                                                   \
     .orc          = 0xFE,                                                   \
     .irq_priority = NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY,                  \
+    .skip_gpio_cfg = false                                                \
 }
 
 /** @brief SPI peripheral device configuration data. */
@@ -151,6 +152,7 @@ typedef struct
     uint8_t              def;           //!< Character clocked out in case of an ignored transaction.
     uint8_t              orc;           //!< Character clocked out after an over-read of the transmit buffer.
     uint8_t              irq_priority;  //!< Interrupt priority.
+    bool                 skip_gpio_cfg; /**< Do not change GPIO configuration */
 } nrfx_spis_config_t;
 
 

--- a/drivers/include/nrfx_spis.h
+++ b/drivers/include/nrfx_spis.h
@@ -131,7 +131,7 @@ typedef struct
     .def          = 0xFF,                                                   \
     .orc          = 0xFE,                                                   \
     .irq_priority = NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY,                  \
-    .skip_gpio_cfg = false                                                \
+    .skip_gpio_cfg = false                                                  \
 }
 
 /** @brief SPI peripheral device configuration data. */
@@ -152,7 +152,10 @@ typedef struct
     uint8_t              def;           //!< Character clocked out in case of an ignored transaction.
     uint8_t              orc;           //!< Character clocked out after an over-read of the transmit buffer.
     uint8_t              irq_priority;  //!< Interrupt priority.
-    bool                 skip_gpio_cfg; /**< Do not change GPIO configuration */
+    bool                 skip_gpio_cfg; ///< Skip the GPIO configuration
+                                        /**< When this flag is set, the user is responsible for
+                                        *   providing the proper configuration of the output pins,
+                                        *   as the driver does not touch it at all. */
 } nrfx_spis_config_t;
 
 

--- a/drivers/src/nrfx_spis.c
+++ b/drivers/src/nrfx_spis.c
@@ -182,49 +182,52 @@ nrfx_err_t nrfx_spis_init(nrfx_spis_t const *        p_instance,
     uint32_t mosi_pin;
     uint32_t miso_pin;
 
-    if (p_config->miso_pin != NRFX_SPIS_PIN_NOT_USED)
+    if (!p_config->skip_gpio_cfg)
     {
-        nrf_gpio_cfg(p_config->miso_pin,
+        if (p_config->miso_pin != NRFX_SPIS_PIN_NOT_USED)
+        {
+            nrf_gpio_cfg(p_config->miso_pin,
+                         NRF_GPIO_PIN_DIR_INPUT,
+                         NRF_GPIO_PIN_INPUT_CONNECT,
+                         NRF_GPIO_PIN_NOPULL,
+                         p_config->miso_drive,
+                         NRF_GPIO_PIN_NOSENSE);
+            miso_pin = p_config->miso_pin;
+        }
+        else
+        {
+            miso_pin = NRF_SPIS_PIN_NOT_CONNECTED;
+        }
+
+        if (p_config->mosi_pin != NRFX_SPIS_PIN_NOT_USED)
+        {
+            nrf_gpio_cfg(p_config->mosi_pin,
+                         NRF_GPIO_PIN_DIR_INPUT,
+                         NRF_GPIO_PIN_INPUT_CONNECT,
+                         NRF_GPIO_PIN_NOPULL,
+                         NRF_GPIO_PIN_S0S1,
+                         NRF_GPIO_PIN_NOSENSE);
+            mosi_pin = p_config->mosi_pin;
+        }
+        else
+        {
+            mosi_pin = NRF_SPIS_PIN_NOT_CONNECTED;
+        }
+
+        nrf_gpio_cfg(p_config->csn_pin,
                      NRF_GPIO_PIN_DIR_INPUT,
                      NRF_GPIO_PIN_INPUT_CONNECT,
-                     NRF_GPIO_PIN_NOPULL,
-                     p_config->miso_drive,
+                     p_config->csn_pullup,
+                     NRF_GPIO_PIN_S0S1,
                      NRF_GPIO_PIN_NOSENSE);
-        miso_pin = p_config->miso_pin;
-    }
-    else
-    {
-        miso_pin = NRF_SPIS_PIN_NOT_CONNECTED;
-    }
 
-    if (p_config->mosi_pin != NRFX_SPIS_PIN_NOT_USED)
-    {
-        nrf_gpio_cfg(p_config->mosi_pin,
+        nrf_gpio_cfg(p_config->sck_pin,
                      NRF_GPIO_PIN_DIR_INPUT,
                      NRF_GPIO_PIN_INPUT_CONNECT,
                      NRF_GPIO_PIN_NOPULL,
                      NRF_GPIO_PIN_S0S1,
                      NRF_GPIO_PIN_NOSENSE);
-        mosi_pin = p_config->mosi_pin;
     }
-    else
-    {
-        mosi_pin = NRF_SPIS_PIN_NOT_CONNECTED;
-    }
-
-    nrf_gpio_cfg(p_config->csn_pin,
-                 NRF_GPIO_PIN_DIR_INPUT,
-                 NRF_GPIO_PIN_INPUT_CONNECT,
-                 p_config->csn_pullup,
-                 NRF_GPIO_PIN_S0S1,
-                 NRF_GPIO_PIN_NOSENSE);
-
-    nrf_gpio_cfg(p_config->sck_pin,
-                 NRF_GPIO_PIN_DIR_INPUT,
-                 NRF_GPIO_PIN_INPUT_CONNECT,
-                 NRF_GPIO_PIN_NOPULL,
-                 NRF_GPIO_PIN_S0S1,
-                 NRF_GPIO_PIN_NOSENSE);
 
     nrf_spis_pins_set(p_spis, p_config->sck_pin, mosi_pin, miso_pin, p_config->csn_pin);
 


### PR DESCRIPTION
Add the skip_gpio_cfg field to the nrfx_spis_config_t structure in nrfx_spis.h and initialize it to false.

Skip the gpio setting by adding an if branc In nrfx_spis.c.